### PR TITLE
Allows cancellation of synchronizer.read requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ngx"
   ],
   "scripts": {
-    "prebuild:js": "yarn test",
+    "prebuild:js": "yarn test && yarn lint",
     "build:js": "node ./scripts/build.js",
     "pretest": "node ./scripts/pretest.js",
     "test": "node ./scripts/test.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxs-synchronizers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Easily keep your app's local state synchronized with your backend, databases and more! ngxs-synchronizers simplifies synchronizing your NGXS-based application state with external data sources.",
   "author": "Mychal Thompson <mychal.r.thompson@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "prebuild:js": "yarn test",
     "build:js": "node ./scripts/build.js",
     "pretest": "node ./scripts/pretest.js",
-    "test": "node ./scripts/test.js"
+    "test": "node ./scripts/test.js",
+    "lint": "./node_modules/.bin/tslint --project ."
   },
   "peerDependencies": {
     "@angular/core": "6.x.x - 8.x.x",

--- a/src/state-selector.ts
+++ b/src/state-selector.ts
@@ -70,9 +70,6 @@ export class StateSelector<T> {
         return merge(...propertyNames.map(propertyName => this.onPropertySynced(propertyName)));
     }
 
-    public require<OptsT = any>(propertyName: keyof T, options?: Synchronizer.Options<OptsT>): Observable<T>;
-    public require<OptsT = any>(propertyNames: Array<keyof T>, options?: Synchronizer.Options<OptsT>): Observable<T>;
-
     public require<OptsT = any>(propertyNames: keyof T | Array<keyof T>, options?: Synchronizer.Options<OptsT>): Observable<T> {
         if (Array.isArray(propertyNames)) {
             return this.requireAll(propertyNames, options);
@@ -83,6 +80,18 @@ export class StateSelector<T> {
 
     public requireProperty<OptsT = any>(propertyName: keyof T, options?: Synchronizer.Options<OptsT>): Observable<T[typeof propertyName]> {
         return this.requireOne<OptsT>(propertyName, options).pipe(map(session => session[propertyName]));
+    }
+
+    public sync<OptsT = any>(propertyNames: keyof T | Array<keyof T>, options?: Synchronizer.Options<OptsT>): Observable<T> {
+        if (Array.isArray(propertyNames)) {
+            return this.syncAll(propertyNames, options);
+        } else {
+            return this.syncOne(propertyNames, options);
+        }
+    }
+
+    public syncProperty<OptsT = any>(propertyName: keyof T, options?: Synchronizer.Options<OptsT>): Observable<T[typeof propertyName]> {
+        return this.syncOne<OptsT>(propertyName, options).pipe(map(session => session[propertyName]));
     }
 
     private requireOne<OptsT = any>(propertyName: keyof T, options?: Synchronizer.Options<OptsT>): Observable<T> {
@@ -120,21 +129,6 @@ export class StateSelector<T> {
                 })
             );
         }
-    }
-
-    public sync<OptsT = any>(propertyName: keyof T, options?: Synchronizer.Options<OptsT>): Observable<T>;
-    public sync<OptsT = any>(propertyNames: Array<keyof T>, options?: Synchronizer.Options<OptsT>): Observable<T>;
-
-    public sync<OptsT = any>(propertyNames: keyof T | Array<keyof T>, options?: Synchronizer.Options<OptsT>): Observable<T> {
-        if (Array.isArray(propertyNames)) {
-            return this.syncAll(propertyNames, options);
-        } else {
-            return this.syncOne(propertyNames, options);
-        }
-    }
-
-    public syncProperty<OptsT = any>(propertyName: keyof T, options?: Synchronizer.Options<OptsT>): Observable<T[typeof propertyName]> {
-        return this.syncOne<OptsT>(propertyName, options).pipe(map(session => session[propertyName]));
     }
 
     private syncOne<OptsT = any>(propertyName: keyof T, options?: Synchronizer.Options<OptsT>): Observable<T> {

--- a/src/state-selector.ts
+++ b/src/state-selector.ts
@@ -1,6 +1,6 @@
 import { Store } from "@ngxs/store";
 import { BehaviorSubject, forkJoin, merge, Observable, of, throwError, zip } from "rxjs";
-import { catchError, distinctUntilChanged, filter, map, mergeMap, shareReplay, take, tap } from "rxjs/operators";
+import { catchError, distinctUntilChanged, filter, map, mergeMap, publishReplay, refCount, take, tap } from "rxjs/operators";
 import { SyncState } from "./decorators/sync-state";
 import { Synchronizer } from "./synchronizer";
 
@@ -175,7 +175,8 @@ export class StateSelector<T> {
                         }),
                         tap(() => this.clearPropertyUpdater(propertyName, pendingRequest$)), // Remove the pending request
                         mergeMap(() => this.state$.pipe(take(1))), // Get the newly updated Session
-                        shareReplay(1)
+                        publishReplay(1),
+                        refCount()
                     );
 
                     this.pendingRequests$.next(Object.assign(pendingRequests, { [propertyName]: pendingRequest$ }));

--- a/src/sychronizers.ts
+++ b/src/sychronizers.ts
@@ -1,5 +1,5 @@
 import { Injector } from "@angular/core";
-import { Synchronizer, PropertySynchronizer, CollectionSynchronizer } from "./synchronizer";
+import { CollectionSynchronizer, PropertySynchronizer, Synchronizer } from "./synchronizer";
 
 export class Synchronizers {
 

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -18,8 +18,7 @@ export interface PropertySynchronizer<
     T,
     PropKey extends keyof T,
     ParamsT = any
-> extends Synchronizer<T, PropKey, ParamsT>
-{
+> extends Synchronizer<T, PropKey, ParamsT> {
     property: PropKey;
 
     read(


### PR DESCRIPTION
* Fixes TSLint errors.
* Replaces shareReplay with publishReplay and refCount because shareReplay was failing to cancel requests on synchronizer.read calls.
* Bumps version to 0.2.1